### PR TITLE
Chen formula

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .idea/misc.xml
 .idea/workspace.xml
+tests/.pytest_cache

--- a/chen_formula.py
+++ b/chen_formula.py
@@ -1,0 +1,91 @@
+from math import ceil
+from pypokerengine.engine.card import Card
+
+# Do not use `Card.RANK_MAP.get(12)` as it would return the Card's character, e.g. 1,2,...10,J,Q,K,A
+ACE = 14
+KING = 13
+QUEEN = 12
+JACK = 12
+
+
+class ChenFormula:
+    """
+    Implements Chen Formula as described by http://www.thepokerbank.com/strategy/basic/starting-hand-selection/chen-formula/
+    It is used for scoring different STARTING (hole) hands only. This does not take into consideration of community cards.
+    Note that this should only be used as a guideline as to whether to play your hand, where by the formula can help
+    inform you what hands to play, but it can't tell you when to call, raise, or fold.
+    For more info: https://poker.stackexchange.com/questions/2687/how-to-use-or-not-use-chen-formula-valuation-in-different-scenarios
+    """
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def score(our_starting_hand):
+        """
+        :param our_starting_hand: The 2 hole cards
+        :return: score as integer
+        """
+
+        if len(our_starting_hand) != 2:
+            raise Exception("Your starting hands must have 2 cards!")
+
+        card_one_rank = Card.from_str(our_starting_hand[0]).rank
+        card_one_suit = Card.from_str(our_starting_hand[0]).suit
+        card_two_rank = Card.from_str(our_starting_hand[1]).rank
+        card_two_suit = Card.from_str(our_starting_hand[1]).suit
+
+        high_rank = max(card_one_rank, card_two_rank)
+        low_rank = min(card_one_rank, card_two_rank)
+        rank_difference = high_rank - low_rank
+        gap_between_cards = rank_difference - 1 if rank_difference > 1 else 0
+        is_pair = card_one_rank == card_two_rank
+        is_suited = card_one_suit == card_two_suit
+
+        if high_rank == ACE:
+            score = 10.0
+        elif high_rank == KING:
+            score = 8.0
+        elif high_rank == QUEEN:
+            score = 7.0
+        elif high_rank == JACK:
+            score = 6.0
+        else:
+            score = high_rank / 2.0
+
+        """
+        If cards are a pair, multiply the score by 2. 
+        If the resulting score is < 5.0, set score to 5.0 as the minimum score for a pair is 5.0.
+        """
+        if is_pair:
+            score *= 2
+            if score < 5.0:
+                score = 5.0
+
+        """
+        If cards have the same suit, add 2 to the score.
+        """
+        if is_suited:
+            score += 2.0
+
+        """
+        Update score based on gap between cards.
+        E.g. 5 and 7 has a gap of 1, 5 and 6 has a gap of 0, 5 and 10 has a gap of 4.
+        However, ACE is special in this case where it is considered to be 4 gaps or more.
+        E.g. A and 2 has a gap of at least 4
+        """
+        if 1 <= gap_between_cards <= 2:
+            score -= gap_between_cards
+        elif gap_between_cards == 3:
+            score -= 4.0
+        elif gap_between_cards > 3:
+            score -= 5.0
+
+        """
+        Add 1 point if there is 0 or 1 gap between cards, and both cards are lower than QUEEN".
+        This does not apply to pair cards.       
+        """
+        if not is_pair and gap_between_cards <= 1 and card_one_rank < QUEEN and card_two_rank < QUEEN:
+            score += 1.0
+
+        return ceil(score)

--- a/chen_formula.py
+++ b/chen_formula.py
@@ -5,7 +5,7 @@ from pypokerengine.engine.card import Card
 ACE = 14
 KING = 13
 QUEEN = 12
-JACK = 12
+JACK = 11
 
 
 class ChenFormula:
@@ -34,6 +34,9 @@ class ChenFormula:
         card_one_suit = Card.from_str(our_starting_hand[0]).suit
         card_two_rank = Card.from_str(our_starting_hand[1]).rank
         card_two_suit = Card.from_str(our_starting_hand[1]).suit
+
+        if card_one_rank == card_two_rank and card_one_suit == card_two_suit:
+            raise Exception("You cannot have 2 cards of the same rank and suite!")
 
         high_rank = max(card_one_rank, card_two_rank)
         low_rank = min(card_one_rank, card_two_rank)
@@ -78,7 +81,7 @@ class ChenFormula:
             score -= gap_between_cards
         elif gap_between_cards == 3:
             score -= 4.0
-        elif gap_between_cards > 3:
+        elif gap_between_cards >= 4:
             score -= 5.0
 
         """

--- a/monte_carlo_player.py
+++ b/monte_carlo_player.py
@@ -36,5 +36,6 @@ class MonteCarloPlayer(BasePokerPlayer):
   def receive_round_result_message(self, winners, hand_info, round_state):
     pass
 
+
 def setup_ai():
-  return RandomPlayer()
+  return MonteCarloPlayer()

--- a/raise_player.py
+++ b/raise_player.py
@@ -2,15 +2,16 @@ from pypokerengine.players import BasePokerPlayer
 from time import sleep
 import pprint
 
+
 class RaisedPlayer(BasePokerPlayer):
 
   def declare_action(self, valid_actions, hole_card, round_state):
     for i in valid_actions:
-        if i["action"] == "raise":
-            action = i["action"]
-            return action  # action returned here is sent to the poker engine
+      if i["action"] == "raise":
+        action = i["action"]
+        return action  # action returned here is sent to the poker engine
     action = valid_actions[1]["action"]
-    return action # action returned here is sent to the poker engine
+    return action  # action returned here is sent to the poker engine
 
   def receive_game_start_message(self, game_info):
     pass
@@ -26,9 +27,9 @@ class RaisedPlayer(BasePokerPlayer):
 
   def receive_round_result_message(self, winners, hand_info, round_state):
     # output action history
-    print("My ID (round result - random) : "+self.uuid)
+    print("My ID (round result - random) : " + self.uuid)
     pprint.pprint(round_state)
 
 
 def setup_ai():
-  return RandomPlayer()
+  return RaisedPlayer()

--- a/testperf.py
+++ b/testperf.py
@@ -62,7 +62,7 @@ def testperf(agent_name1, agent1, agent_name2, agent2):
         print("\n Congratulations! " + agent_name1 + " has won.")
     # print("\n Random Player has won!")
     else:
-        Print("\n It's a draw!")
+        print("\n It's a draw!")
 
 
 def parse_arguments():

--- a/tests/.pytest_cache/README.md
+++ b/tests/.pytest_cache/README.md
@@ -1,8 +1,0 @@
-# pytest cache directory #
-
-This directory contains data from the pytest's cache plugin,
-which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
-
-**Do not** commit this to version control.
-
-See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.

--- a/tests/.pytest_cache/v/cache/lastfailed
+++ b/tests/.pytest_cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "test_ehs.py": true
-}

--- a/tests/.pytest_cache/v/cache/nodeids
+++ b/tests/.pytest_cache/v/cache/nodeids
@@ -1,3 +1,0 @@
-[
-  "test_ehs.py::TestEffectiveHandStrengh::test_handStrength"
-]

--- a/tests/test_chen_formula.py
+++ b/tests/test_chen_formula.py
@@ -18,13 +18,16 @@ class TestChenFormula(unittest.TestCase):
 
     def test_chen_formula_exception(self):
         with self.assertRaises(Exception) as error:
-            self.hand_strength.score(["SA"])
+            self.hand_strength.score([]) # Empty
         self.assertTrue('Your starting hands must have 2 cards!' in error.exception)
         with self.assertRaises(Exception) as error:
-            self.hand_strength.score(["SA"])
+            self.hand_strength.score(["SA"]) # 1 card
         self.assertTrue('Your starting hands must have 2 cards!' in error.exception)
         with self.assertRaises(Exception) as error:
-            self.hand_strength.score(["SA", "SA"])
+            self.hand_strength.score(["SA", "DA", "CA"]) # 3 cards
+        self.assertTrue('Your starting hands must have 2 cards!' in error.exception)
+        with self.assertRaises(Exception) as error:
+            self.hand_strength.score(["SA", "SA"]) # 2 same cards
         self.assertTrue('You cannot have 2 cards of the same rank and suite!' in error.exception)
 
     def tearDown(self):

--- a/tests/test_chen_formula.py
+++ b/tests/test_chen_formula.py
@@ -1,0 +1,19 @@
+from chen_formula import ChenFormula
+import unittest
+
+class TestChenFormula(unittest.TestCase):
+    def test_chen_formula(self):
+        hand_strength = ChenFormula()
+        self.assertEqual(hand_strength.score(["SA", "SK"]), 12.0)
+        self.assertEqual(hand_strength.score(["CT", "DT"]), 10.0)
+        self.assertEqual(hand_strength.score(["H5", "H7"]), 6.0)
+        self.assertEqual(hand_strength.score(["C2", "H7"]), -1.0)
+        self.assertEqual(hand_strength.score(["CA", "HA"]), 20.0)
+        self.assertEqual(hand_strength.score(["SA", "S2"]), 7.0)
+        with self.assertRaises(Exception) as context:
+            hand_strength.score(["SA"])
+        self.assertTrue('Your starting hands must have 2 cards!' in context.exception)
+
+if __name__ == '__main__':
+    # Only run this tests if it's not imported as a module
+    unittest.main()

--- a/tests/test_chen_formula.py
+++ b/tests/test_chen_formula.py
@@ -1,18 +1,35 @@
 from chen_formula import ChenFormula
 import unittest
 
+
 class TestChenFormula(unittest.TestCase):
+    def setUp(self):
+        self.hand_strength = ChenFormula()
+
     def test_chen_formula(self):
-        hand_strength = ChenFormula()
-        self.assertEqual(hand_strength.score(["SA", "SK"]), 12.0)
-        self.assertEqual(hand_strength.score(["CT", "DT"]), 10.0)
-        self.assertEqual(hand_strength.score(["H5", "H7"]), 6.0)
-        self.assertEqual(hand_strength.score(["C2", "H7"]), -1.0)
-        self.assertEqual(hand_strength.score(["CA", "HA"]), 20.0)
-        self.assertEqual(hand_strength.score(["SA", "S2"]), 7.0)
-        with self.assertRaises(Exception) as context:
-            hand_strength.score(["SA"])
-        self.assertTrue('Your starting hands must have 2 cards!' in context.exception)
+        self.assertEqual(self.hand_strength.score(["SA", "SK"]), 12.0)
+        self.assertEqual(self.hand_strength.score(["CT", "DT"]), 10.0)
+        self.assertEqual(self.hand_strength.score(["H5", "H7"]), 6.0)
+        self.assertEqual(self.hand_strength.score(["C2", "H7"]), -1.0)
+        self.assertEqual(self.hand_strength.score(["CA", "HA"]), 20.0)
+        self.assertEqual(self.hand_strength.score(["SA", "S2"]), 7.0)
+        self.assertEqual(self.hand_strength.score(["SJ", "S5"]), 3)
+        self.assertEqual(self.hand_strength.score(["CQ", "D6"]), 2)
+
+    def test_chen_formula_exception(self):
+        with self.assertRaises(Exception) as error:
+            self.hand_strength.score(["SA"])
+        self.assertTrue('Your starting hands must have 2 cards!' in error.exception)
+        with self.assertRaises(Exception) as error:
+            self.hand_strength.score(["SA"])
+        self.assertTrue('Your starting hands must have 2 cards!' in error.exception)
+        with self.assertRaises(Exception) as error:
+            self.hand_strength.score(["SA", "SA"])
+        self.assertTrue('You cannot have 2 cards of the same rank and suite!' in error.exception)
+
+    def tearDown(self):
+        self.hand_strength = None
+
 
 if __name__ == '__main__':
     # Only run this tests if it's not imported as a module

--- a/tests/test_ehs.py
+++ b/tests/test_ehs.py
@@ -2,7 +2,6 @@ from utils import *
 from effective_hand_strength import HandStrengthEval
 import unittest
 
-
 class TestUtilities(unittest.TestCase):
     def test_set_product(self):
         set1 = ["A", "B"]
@@ -12,15 +11,19 @@ class TestUtilities(unittest.TestCase):
         self.assertEqual(res, ["A1", "A2", "B1", "B2"])
 
     def test_combinations(self):
-        res = get_all_combinations([1,2,3,4], 2)
-        print(res)
+        res = get_all_combinations([1, 2, 3, 4], 2)
         self.assertEqual(len(res), 6)
         res = set(res)
         self.assertEqual(len(res), 6)
 
-class TestEffectiveHandStrengh(unittest.TestCase):
+
+class TestEffectiveHandStrength(unittest.TestCase):
 
     def test_handStrength(self):
         hand_strength = HandStrengthEval()
-        print(hand_strength.hand_strength(["CQ","CK"], []))
+        result = hand_strength.hand_strength(["CQ", "CK"], [])
+        self.assertEqual(result, 0)
 
+if __name__ == '__main__':
+    # Only run this tests if it's not imported as a module
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,19 +1,3 @@
-from itertools import combinations
-
-def set_product(set1, set2):
-    res = []
-    for i in set1:
-        for j in set2:
-            res.append(i+j)
-    return res
-
-
-def get_all_possible_cards():
-    numbers = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"]
-    suites = ["S", "D", "H", "C"]
-    return set_product(suites, numbers)
-
-
-def get_all_combinations(cards, n):
-
-    return list(combinations(cards, n))
+# Declare "public" API for the module
+# __init__ file make Python treat this directory as containing packages
+from utility import get_all_combinations, get_all_possible_cards, set_product

--- a/utils/utility.py
+++ b/utils/utility.py
@@ -1,0 +1,18 @@
+from itertools import combinations
+
+def set_product(set1, set2):
+    res = []
+    for i in set1:
+        for j in set2:
+            res.append(i+j)
+    return res
+
+
+def get_all_possible_cards():
+    numbers = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"]
+    suites = ["S", "D", "H", "C"]
+    return set_product(suites, numbers)
+
+
+def get_all_combinations(cards, n):
+    return list(combinations(cards, n))


### PR DESCRIPTION
Closes #7 

The formula is only used for scoring different **starting** hands only. It should not be used as a complete substitute for proper **pre-flop** starting hand strategy, but could be used as one of the heuristics. However, this is till a rather decent formula to work out **pre-flop** starting hand strengths. 

Implementation is based on http://www.thepokerbank.com/strategy/basic/starting-hand-selection/chen-formula/ 